### PR TITLE
Feat: Rolled back to non-ncurses version and removed -lncurses from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LDFLAGS := -fsanitize=address
 
 LIBS:= fmt spdlog
 LIB_FLAGS := $(addprefix -l,$(LIBS))
-LDFLAGS += $(LIB_FLAGS) -lncurses -pthread
+LDFLAGS += $(LIB_FLAGS) -pthread
 
 BUILD_DIR := build
 SRC_DIR := src

--- a/src/client-main.cc
+++ b/src/client-main.cc
@@ -118,10 +118,6 @@ int main(int argc, char* argv[]) {
                 break;
             }
         }
-        // Only print prompt if still running, otherwise it might print after "shutting down" messages
-        if (g_client_running) {
-            std::cout << "> " << std::flush;
-        }
     }
 
     // Handle EOF (Ctrl+D) on std::cin or if loop exited due to g_client_running

--- a/src/client-main.cc
+++ b/src/client-main.cc
@@ -1,199 +1,158 @@
-// client-main.cc
-#include <cstdlib>
-#include <iostream>
+#include <iostream>     
 #include <string>
 #include <thread>
-#include <mutex>
 #include <atomic>
-#include <memory> // For std::unique_ptr
+#include <csignal>      
+#include <memory>      
+#include <vector>       
 
-#include <ncurses.h>
 #include <spdlog/spdlog.h>
+#include <unistd.h>     
+#include <sys/socket.h> 
+#include <errno.h>      
 
-// Forward declare or include your client class header
-#include "client/chat-client.h"
+#include "client/chat-client.h" // Assuming Client.h has send_message & get_socket_fd
 
-// Global ncurses windows and synchronization primitives
-WINDOW* g_chat_win = nullptr;
-WINDOW* g_input_win = nullptr;
-std::mutex g_ncurses_mutex;
-std::atomic<bool> g_client_running{true}; // Initialize to true
+std::atomic<bool> g_client_running{true};
+
 
 void read_loop(int client_socket_fd) {
     char buffer[2048];
-    SPDLOG_INFO("Read loop started for FD {}", client_socket_fd);
-    if (client_socket_fd < 0) { 
-      g_client_running = false; 
-      return; 
+    spdlog::info("Read loop started for FD {}", client_socket_fd);
+
+    if (client_socket_fd < 0) {
+        spdlog::error("Read loop received invalid socket FD. Terminating read loop.");
+        g_client_running = false; // Signal main loop to exit
+        return;
     }
 
     while (g_client_running) {
         ssize_t n = read(client_socket_fd, buffer, sizeof(buffer) - 1);
-        if (!g_client_running) break;
+
+        if (!g_client_running) { // Check after read unblocks
+            break;
+        }
 
         if (n > 0) {
-            std::string msg(buffer, n);
-            std::lock_guard<std::mutex> lock(g_ncurses_mutex);
-            if (g_chat_win) {
-                wprintw(g_chat_win, "Server: %s\n", msg.c_str()); // Simple display
-                wrefresh(g_chat_win);
+            // Null-terminate the received data before printing
+            buffer[n] = '\0';
+            std::cout << buffer << std::endl;
+        } else if (n == 0) {
+            std::cout << "--- Server closed connection ---" << std::endl;
+            g_client_running = false; // Signal main loop to exit
+            break;
+        } else { // n < 0, read error
+            if (errno == EINTR && g_client_running) {
+                // Interrupted by a signal (e.g., SIGINT), but we're still running.
+                continue;
             }
-        } else if (n == 0) { /* server closed */ g_client_running = false; break; }
-        else { /* read error */ if (errno == EINTR) continue; g_client_running = false; break; }
+            if (g_client_running) { // Only print error if not intentionally shutting down
+                std::cerr << "--- Read error: " << strerror(errno) << " ---" << std::endl;
+            }
+            g_client_running = false; // Signal main loop to exit
+            break;
+        }
     }
-    SPDLOG_INFO("Read loop terminated.");
+    spdlog::info("Read loop terminated for FD {}", client_socket_fd);
 }
 
+
 int main(int argc, char* argv[]) {
-    const char* server_ip = "127.0.0.1";
+    // Basic command line argument parsing
+    std::string server_ip = "127.0.0.1";
     int port = 8080;
 
-    if (argc > 1) server_ip = argv[1];
+    if (argc > 1) {
+        server_ip = argv[1];
+    }
     if (argc > 2) {
-        try { port = std::stoi(argv[2]); }
-        catch (const std::exception& e) {
-            std::cerr << "Invalid port: " << argv[2] << ". Using default " << port << std::endl;
+        try {
+            port = std::stoi(argv[2]);
+        } catch (const std::exception& e) {
+            std::cerr << "Invalid port number: " << argv[2] << ". Using default " << port << std::endl;
         }
     }
 
-    // --- Init ncurses ---
-    initscr();
-    if (has_colors()) {
-        start_color();
-        // Basic color pairs (can be expanded later)
-        init_pair(1, COLOR_CYAN, COLOR_BLACK);
-        init_pair(2, COLOR_YELLOW, COLOR_BLACK);
-    }
-    cbreak(); // Line buffering off
-    echo(); 
-
-    int terminal_rows, terminal_cols;
-    getmaxyx(stdscr, terminal_rows, terminal_cols);
-    int chat_win_height = terminal_rows - 3;
-
-    g_chat_win = newwin(chat_win_height, terminal_cols, 0, 0);
-    g_input_win = newwin(3, terminal_cols, chat_win_height, 0);
-
-    if (!g_chat_win || !g_input_win) {
-        if (isendwin() == FALSE) endwin();
-        SPDLOG_CRITICAL("Failed to create ncurses windows.");
-        std::cerr << "Error: Failed to create ncurses windows." << std::endl;
-        // chat_client_ptr destructor will handle socket close
-        return EXIT_FAILURE;
-    }
-
-    scrollok(g_chat_win, TRUE);
-    box(g_input_win, 0, 0);
-    keypad(g_input_win, TRUE); // Enable function keys for input window
-
-    wrefresh(g_chat_win);
-    wrefresh(g_input_win);
-
     spdlog::set_level(spdlog::level::info);
-    SPDLOG_INFO("Client application starting...");
-
-    
-    SPDLOG_INFO("Attempting to connect to server {}:{}", server_ip, port);
+    spdlog::info("Command-line Chat Client starting to connect to {}:{}", server_ip, port);
 
     std::unique_ptr<tt::chat::client::Client> chat_client_ptr;
     try {
         chat_client_ptr = std::make_unique<tt::chat::client::Client>(port, server_ip);
-        SPDLOG_INFO("Successfully connected to the server.");
+        std::cout << "Connected to server. Type messages or '/quit' to exit." << std::endl;
     } catch (const std::runtime_error& e) {
-        SPDLOG_CRITICAL("Failed to connect to server: {}", e.what());
-        std::cerr << "Error: Failed to connect to server: " << e.what() << std::endl;
+        spdlog::critical("Failed to create or connect client: {}", e.what());
+        std::cerr << "Error connecting to server: " << e.what() << std::endl;
         return EXIT_FAILURE;
     } catch (...) {
-        SPDLOG_CRITICAL("An unknown error occurred during client connection.");
-        std::cerr << "An unknown error occurred during client connection." << std::endl;
+        spdlog::critical("An unknown error occurred during client initialization.");
+        std::cerr << "An unknown error occurred during client initialization." << std::endl;
         return EXIT_FAILURE;
     }
+
 
     int client_socket_fd = chat_client_ptr->get_socket_fd();
     std::thread reader_thread(read_loop, client_socket_fd);
-    
-    {
-        std::lock_guard<std::mutex> lock(g_ncurses_mutex);
-        if (g_chat_win) {
-            wprintw(g_chat_win, "Ncurses UI initialized. Type /quit to exit.\n");
-            wrefresh(g_chat_win);
-        }
-    }
 
-    char input_buffer[512];
-    while (g_client_running) { // Use the atomic flag
-        {
-            std::lock_guard<std::mutex> lock(g_ncurses_mutex);
-            if (!g_input_win) { g_client_running = false; break; }
-            werase(g_input_win);
-            box(g_input_win, 0, 0);
-            mvwprintw(g_input_win, 1, 2, "> ");
-            wrefresh(g_input_win);
-        }
+    std::string input_line;
+    std::cout << "> " << std::flush; // Initial prompt
 
-        int get_result = wgetnstr(g_input_win, input_buffer, sizeof(input_buffer) - 1);
-
-        if (!g_client_running) break; // Check after wgetnstr in case of signal
-
-        if (get_result == ERR) {
-            // Basic error handling for now, can be refined
-            std::lock_guard<std::mutex> lock(g_ncurses_mutex);
-            if (g_chat_win) {
-                wprintw(g_chat_win, "--- Error reading input ---\n");
-                wrefresh(g_chat_win);
-            }
-            g_client_running = false; // Exit on error
+    // Main input loop using std::getline
+    while (g_client_running && std::getline(std::cin, input_line)) {
+        if (!g_client_running) { // Check flag, in case signal interrupted getline somehow
             break;
         }
 
-        std::string message_str(input_buffer);
-        if (message_str == "/quit") {
-            g_client_running = false;
+        if (input_line == "/quit") {
+            g_client_running = false; // Signal threads to stop
             break;
         }
 
-        if (!message_str.empty()) {
+        if (!input_line.empty()) {
             try {
-                chat_client_ptr->send_message(message_str);
-                // Still echo locally, or wait for server to echo back via read_loop later
-                std::lock_guard<std::mutex> lock(g_ncurses_mutex);
-                if (g_chat_win) {
-                    wprintw(g_chat_win, "Sent to server: %s\n", message_str.c_str());
-                    wrefresh(g_chat_win);
-                }
+                chat_client_ptr->send_message(input_line);
             } catch (const std::runtime_error& e) {
-                std::lock_guard<std::mutex> lock(g_ncurses_mutex);
-                if (g_chat_win) {
-                    wprintw(g_chat_win, "--- Error sending message: %s ---\n", e.what());
-                    wrefresh(g_chat_win);
-                }
-                g_client_running = false; // Assume connection lost
+                std::cerr << "--- Error sending message: " << e.what() << " ---" << std::endl;
+                // Assume connection is lost if send fails
+                g_client_running = false;
                 break;
             }
         }
+        // Only print prompt if still running, otherwise it might print after "shutting down" messages
+        if (g_client_running) {
+            std::cout << "> " << std::flush;
+        }
     }
 
-    // After input loop finishes (due to /quit or error)
-    SPDLOG_INFO("Main loop ended. Signaling reader thread to stop.");
-    g_client_running = false; // Signal reader thread
+    // Handle EOF (Ctrl+D) on std::cin or if loop exited due to g_client_running
+    if (std::cin.eof() && g_client_running) {
+        std::cout << "\nInput stream closed (EOF). Shutting down..." << std::endl;
+        g_client_running = false;
+    }
+
+
+    spdlog::info("Client main loop terminated. Initiating shutdown sequence...");
+    g_client_running = false; // Ensure flag is definitely false for reader_thread
 
     // Shutdown socket to unblock read() in reader_thread
+
     if (client_socket_fd >= 0) {
+        spdlog::debug("Shutting down socket FD {} for read/write.", client_socket_fd);
         if (shutdown(client_socket_fd, SHUT_RDWR) == -1 && errno != ENOTCONN) {
-             SPDLOG_WARN("Socket shutdown failed: {}", strerror(errno));
+            spdlog::warn("Socket shutdown failed for FD {}: {}", client_socket_fd, strerror(errno));
         }
     }
 
     if (reader_thread.joinable()) {
-        SPDLOG_DEBUG("Joining reader thread...");
+        spdlog::debug("Joining reader thread...");
         reader_thread.join();
-        SPDLOG_DEBUG("Reader thread joined.");
+        spdlog::debug("Reader thread joined.");
     }
 
-    if (g_input_win) { delwin(g_input_win); g_input_win = nullptr; }
-    if (g_chat_win) { delwin(g_chat_win); g_chat_win = nullptr; }
-    if (isendwin() == FALSE) endwin();
+    // chat_client_ptr (unique_ptr) will be destroyed here automatically,
+    // calling Client's destructor which closes the socket.
 
-    SPDLOG_INFO("Client application finished.");
+    std::cout << "Chat client shut down." << std::endl;
+    spdlog::info("Chat client shutdown complete.");
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR reverts the project back to the previous non-ncurses user interface implementation. The ncurses-based UI code has been removed to simplify the interface and avoid the complexities introduced by the ncurses dependency.

Additionally, the Makefile has been updated to remove the -lncurses linker flag, eliminating the dependency on the ncurses library during build.

Changes included:

Reverted UI code to the non-ncurses version.

Removed all ncurses-related code and headers.

Updated Makefile to remove -lncurses linker flag.