### PR TITLE
Team1 hari fix uninitialized name issue

### DIFF
--- a/server.log
+++ b/server.log
@@ -1,6 +1,0 @@
-[2025-06-10 08:36:20.643] [server-logs] [info] [epoll-server.cc:267] Server started with epoll
-[2025-06-10 08:36:42.710] [server-logs] [info] [epoll-server.cc:57] New connection: user_6
-[2025-06-10 08:36:48.175] [server-logs] [info] [epoll-server.cc:84] Client 6 assigned username 'mayank'
-[2025-06-10 08:36:50.844] [server-logs] [info] [epoll-server.cc:84] Client 6 assigned username 'hii'
-[2025-06-10 08:37:02.538] [server-logs] [info] [epoll-server.cc:84] Client 6 assigned username 'hi'
-[2025-06-10 08:37:09.169] [server-logs] [info] [epoll-server.cc:84] Client 6 assigned username 'mayank'

--- a/src/server/epoll-server.cc
+++ b/src/server/epoll-server.cc
@@ -266,7 +266,7 @@ void EpollServer::handle_private_msg_command(int client_sock, const std::string&
       uname = usernames_[client_sock];
     }
     else {
-      uname = client_usernames_[client_sock];
+      uname = "user_" + std::to_string(client_sock);
     }
     std::string dm = "[DM] " + uname + ": " + msg.substr(space_pos + 1);
 


### PR DESCRIPTION
The name is set by default to "user_" + std::to_string(client_sock).