### PR TITLE
Update unitinitialized name to be user_<fd> when sent to other clients

### DIFF
--- a/src/server/epoll-server.cc
+++ b/src/server/epoll-server.cc
@@ -266,7 +266,7 @@ void EpollServer::handle_private_msg_command(int client_sock, const std::string&
       uname = usernames_[client_sock];
     }
     else {
-      uname = client_usernames_[client_sock];
+      uname = "user_" + std::to_string(client_sock);
     }
     std::string dm = "[DM] " + uname + ": " + msg.substr(space_pos + 1);
 


### PR DESCRIPTION
The name is set by default to "user_" + std::to_string(client_sock).
