### PR TITLE
Team3 optimize for the performance of the server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CXX_DEBUG_FLAGS :=-g3 -ggdb3
 CXX_RELEASE_FLAGS :=-O3
 
 # PASS -DIO_URING_ENABLED to use IO_URING instead of EPOLL
-CXXFLAGS += -O0 -g -fno-omit-frame-pointer -DIO_URING_ENABLED
+CXXFLAGS += -O0 -g -fno-omit-frame-pointer #-DIO_URING_ENABLED
 
 CXXFLAGS += $(CXX_DEBUG_FLAGS)
 

--- a/auto_profiler.sh
+++ b/auto_profiler.sh
@@ -6,18 +6,18 @@
 BIN=./build/server
 DURATION=${2:-10}   # seconds
 
-sudo perf record -F 997 -g -- "$BIN" & # For reasons that'll take a while to explain, do NOT make it a multiple of 10.
+sudo perf record -F 197 -g -- "$BIN" & # For reasons that'll take a while to explain, do NOT make it a multiple of 10.
 PID=$!
 echo "Server PID=$PID. Profiling for $DURATION s…"
 
-sleep 4 # sleep long enough to start the server
+sleep 1 # sleep long enough to start the server
 if [[ "$*" == *"--auto"* ]]; then
-    ./test/chat_load_tester 127.0.0.1 8080 100 100 64 1 10 testchannel
+    ./test/chat_load_tester 127.0.0.1 8080 10 1000 64 1 10 testchannel
     # Usage: ./test/chat_load_tester <server_ip> <server_port> <num_clients> <messages_per_client> <message_size_bytes> [listen_replies (0 or 1)] [think_time_ms (0+)] [channel_name]
     # Example: ./test/chat_load_tester 127.0.0.1 8080 10 100 64 1 10 testchannel
 fi
 
-sleep "$DURATION"
+sleep 1
 sudo kill -INT "$PID"   # graceful Ctrl-C
 
 mkdir -p ./profiling-data

--- a/graded_profiler.sh
+++ b/graded_profiler.sh
@@ -1,0 +1,36 @@
+# scripts/profile_server.sh
+#!/usr/bin/env bash
+
+BIN=./build/server
+
+profile_server() {
+    mkdir -p ./profiling-data
+    COMMITHASH=$(git rev-parse --short=7 HEAD)
+
+    sudo perf record -F 997 -g -- "$BIN" & # For reasons that'll take a while to explain, do NOT make it a multiple of 10.
+    PID=$!
+    echo "Server PID=$PID. Profiling for $DURATION s…"
+
+    sleep 4 # sleep long enough to start the server
+    ./test/chat_load_tester 127.0.0.1 8080 $num_c $num_m 64 1 10 | tee ./profiling-data/log-${COMMITHASH}-${num_c}-${num_m}.txt
+    # Usage: ./test/chat_load_tester <server_ip> <server_port> <num_clients> <messages_per_client> <message_size_bytes> [listen_replies (0 or 1)] [think_time_ms (0+)] [channel_name]
+    # Example: ./test/chat_load_tester 127.0.0.1 8080 10 100 64 1 10 testchannel
+    sudo kill -INT "$PID"   # graceful Ctrl-C
+
+    FLAMEGRAPH_FILE="./profiling-data/flame-${COMMITHASH}-${num_c}-${num_m}.svg"
+    sudo perf script -i ./perf.data | perl ./external-tools/FlameGraph/stackcollapse-perf.pl | perl ./external-tools/FlameGraph/flamegraph.pl > "$FLAMEGRAPH_FILE"
+    echo "Flame graph written to $FLAMEGRAPH_FILE"
+}
+
+
+num_m=10
+num_c=1
+max_iter=20
+
+for ((i=1; i<=max_iter; i++)); do
+    echo "Mult is $i (of $iter)"
+    profile_server
+    num_c=$((num_c * 2))
+    profile_server
+    num_m=$((num_m * 2))
+done

--- a/src/server/epoll-server.h
+++ b/src/server/epoll-server.h
@@ -47,7 +47,7 @@ namespace tt::chat::server {
         ~EpollServer();
         void run();
         int send_message(int client_sock, const std::string& message);
-        int send_message(int client_sock, const char* msg, size_t len, int flags);
+        int send_message(int client_sock, const std::string& msg, size_t len, int flags);
 
     private:
         int listen_sock_;


### PR DESCRIPTION
Remove redundant c_str calls.
Use format instead of adding strings.